### PR TITLE
rwj11/563 fix segfault

### DIFF
--- a/analysis.cc
+++ b/analysis.cc
@@ -251,8 +251,10 @@ int main(int argc, char** argv)
 	decltype(toml::parse(inputfilename)) tomldata;
 	try {
 		tomldata = toml::parse(inputfilename);
-	} catch (...) {
-		emsg("toml::parse returns exception");
+	} catch (const std::exception& e) {
+		std::ostringstream oss;
+		oss << "toml::parse returns exception" << e.what();
+		emsg(oss.str());
 #ifdef USE_MPI
 		MPI_Finalize();
 #endif

--- a/analysis.cc
+++ b/analysis.cc
@@ -253,7 +253,7 @@ int main(int argc, char** argv)
 		tomldata = toml::parse(inputfilename);
 	} catch (const std::exception& e) {
 		std::ostringstream oss;
-		oss << "toml::parse returns exception" << e.what();
+		oss << "toml::parse returns exception\n" << e.what();
 		emsg(oss.str());
 #ifdef USE_MPI
 		MPI_Finalize();

--- a/analysis.cc
+++ b/analysis.cc
@@ -252,7 +252,7 @@ int main(int argc, char** argv)
 	try {
 		tomldata = toml::parse(inputfilename);
 	} catch (...) {
-		std::cerr << "toml::parse returns exception\n";
+		emsg("toml::parse returns exception");
 #ifdef USE_MPI
 		MPI_Finalize();
 #endif

--- a/analysis.cc
+++ b/analysis.cc
@@ -248,7 +248,17 @@ int main(int argc, char** argv)
 	if (cmdlineparams.count("inputfile") == 1) {
 		inputfilename = cmdlineparams["inputfile"];
 	}
-  auto tomldata = toml::parse(inputfilename);
+	decltype(toml::parse(inputfilename)) tomldata;
+	try {
+		tomldata = toml::parse(inputfilename);
+	} catch (...) {
+		std::cerr << "toml::parse returns exception\n";
+#ifdef USE_MPI
+		MPI_Finalize();
+#endif
+		exit(EXIT_FAILURE);
+	}
+		
 	vector<string>  tomlkeys = get_toml_keys(tomldata);
 	check_for_undefined_parameters(definedparams, tomlkeys, "in " + inputfilename);
 


### PR DESCRIPTION
Add minimal try/catch block to make the response to exceptions thrown in toml::parser look less alarming.

Catch-all and exit isn't great coding, but doing better probably requires a general policy on error handling.