### PR TITLE
Rwj11/583 fix memory leak

### DIFF
--- a/simulate.cc
+++ b/simulate.cc
@@ -20,20 +20,18 @@ void proportions(DATA &data, MODEL &model, vector< vector <FEV> > &indev);
 /// Simulates data using the MBP algorithm
 void simulatedata(DATA &data, MODEL &model, POPTREE &poptree)
 {
-	
-	MBPCHAIN *mbpchain;
 	vector <SAMPLE> opsamp; 
 		
 	model.infmax = large;
 		
-	mbpchain = new MBPCHAIN(data,model,poptree);
-	mbpchain->init(data,model,poptree,1,0);
+	MBPCHAIN mbpchain{data,model,poptree};
+	mbpchain.init(data,model,poptree,1,0);
 		
-	proportions(data,model,mbpchain->indevi);
+	proportions(data,model,mbpchain.indevi);
 	
-	outputsimulateddata(data,model,poptree,mbpchain->trevi,mbpchain->indevi);
+	outputsimulateddata(data,model,poptree,mbpchain.trevi,mbpchain.indevi);
 	
-	opsamp.push_back(outputsamp(0,0,0,0,data,model,poptree,mbpchain->paramval,0,mbpchain->trevi,mbpchain->indevi));
+	opsamp.push_back(outputsamp(0,0,0,0,data,model,poptree,mbpchain.paramval,0,mbpchain.trevi,mbpchain.indevi));
 	outputresults(data,model,opsamp);
 }
 


### PR DESCRIPTION
Fix leak -- object didn't need to be allocated on heap, and object does not appear to be sliced by any called routine.