### PR TITLE
Convert include guards to standard C++ form

### DIFF
--- a/MBP.hh
+++ b/MBP.hh
@@ -1,5 +1,7 @@
-#pragma once
+#ifndef BEEPMBP__MBP_HH
+#define BEEPMBP__MBP_HH
 
 using namespace std;
 
 void MBP(DATA &data, MODEL &model, POPTREE &poptree, unsigned int nsamp, unsigned int core, unsigned int ncore, unsigned int npart);
+#endif

--- a/MBPCHAIN.hh
+++ b/MBPCHAIN.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__MBPCHAIN_HH
+#define BEEPMBP__MBPCHAIN_HH
 
 #include <vector>
 
@@ -106,3 +107,4 @@ class MBPCHAIN                                          // Stores all the things
 		void betaphi_prop( unsigned int samp, unsigned int burnin);
 		void addrem_prop(unsigned int samp, unsigned int burnin);
 };
+#endif

--- a/consts.hh
+++ b/consts.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__CONSTS_HH
+#define BEEPMBP__CONSTS_HH
 
 using namespace std;
 
@@ -26,3 +27,4 @@ const unsigned int BUFMAX = 20000;                             // The maximum bu
 const double varfac = 4;                                         // A factor which relaxes the observation model
 
 const unsigned int BOTH=0, PONLY=1, NOT=2;                       // Use to classify particles in MBPs
+#endif

--- a/data.hh
+++ b/data.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__DATA_HH
+#define BEEPMBP__DATA_HH
 
 //#include "model.hh"
 
@@ -224,3 +225,4 @@ class DATA
 	unsigned int findcol(TABLE &tab, string name);
 	void normaliseQ(unsigned int q);
 };
+#endif

--- a/generateQ.hh
+++ b/generateQ.hh
@@ -1,7 +1,10 @@
-#pragma once
+#ifndef BEEPMBP__GENERATEQ_HH
+#define BEEPMBP__GENERATEQ_HH
 
 using namespace std;
 
 #include "data.hh"
 
 void generateQ(GENQ genq);
+
+#endif

--- a/model.hh
+++ b/model.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__MODEL_HH
+#define BEEPMBP__MODEL_HH
 
 #include <vector>
 
@@ -155,3 +156,4 @@ private:
 	double likelihood_dt(vector <double> &paramv);
 	double dlikelihood_dt(vector <double> &paramvi, vector <double> &paramvf);
 };
+#endif

--- a/obsmodel.hh
+++ b/obsmodel.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__OBSMODEL_HH
+#define BEEPMBP__OBSMODEL_HH
 
 #include <iostream>
 #include <vector>
@@ -18,3 +19,4 @@ vector <unsigned int> getnumtrans(DATA &data, MODEL &model, POPTREE &poptree, ve
 double Lobs(DATA &data, MODEL &model, POPTREE &poptree,  vector < vector <EVREF> > &trev, vector < vector <FEV> > &indev);
 
 MEAS getmeas(DATA &data, MODEL &model, POPTREE &poptree, vector < vector <EVREF> > &trev, vector < vector <FEV> > &indev);
+#endif

--- a/output.hh
+++ b/output.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__OUTPUT_HH
+#define BEEPMBP__OUTPUT_HH
 
 #include "poptree.hh"
 
@@ -17,3 +18,4 @@ void outputresults(DATA &data, MODEL &model, vector <SAMPLE> &opsamp);
 void outputplot(string file, DATA &data, MODEL &model,  vector < vector <FEV> > &xi, double tmin, double period);
 void outputeventsample(vector < vector <FEV> > &fev, DATA &data, MODEL &model, POPTREE &poptree);
 void outputsimulateddata(DATA &data, MODEL &model, POPTREE &poptree, vector < vector <EVREF> > &trev, vector < vector <FEV> > &indev, string dir);
+#endif

--- a/pack.hh
+++ b/pack.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__PACK_HH
+#define BEEPMBP__PACK_HH
 
 using namespace std;
 
@@ -40,5 +41,4 @@ void unpack(vector <REGION> &vec);
 void unpack(vector <DEMOCAT> &vec);
 void unpack(vector <vector <EVREF> > &vec);
 
-	
-	
+#endif

--- a/poptree.hh
+++ b/poptree.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__POPTREE_HH
+#define BEEPMBP__POPTREE_HH
 
 #include <vector>
 #include "model.hh"
@@ -27,3 +28,4 @@ class POPTREE
 	vector <LEVEL> lev;                     // Stores information about different levels on the tree
 	unsigned int level;                     // The number of levels of scale in the model
 };
+#endif

--- a/simulate.cc
+++ b/simulate.cc
@@ -4,8 +4,10 @@
 #include <fstream>
 #include <algorithm>
 
-#include "assert.h"
-#include "math.h"
+#include <assert.h>
+#include <math.h>
+
+#include "simulate.hh"
 
 #include "utils.hh"
 #include "timers.hh"

--- a/simulate.hh
+++ b/simulate.hh
@@ -1,1 +1,9 @@
+#ifndef BEEPMBP__SIMULATE_HH
+#define BEEPMBP__SIMULATE_HH
+
+class DATA;
+class MODEL;
+class POPTREE;
 void simulatedata(DATA &data, MODEL &model, POPTREE &poptree);
+
+#endif

--- a/timers.hh
+++ b/timers.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__TIMERS_HH
+#define BEEPMBP__TIMERS_HH
 
 struct TIMERS {
 	long timetot;
@@ -20,3 +21,4 @@ struct TIMERS {
 extern TIMERS timers;
 
 void timersinit();
+#endif

--- a/utils.hh
+++ b/utils.hh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef BEEPMBP__UTILS_HH
+#define BEEPMBP__UTILS_HH
 
 #define USE_MPI 1
 
@@ -24,3 +25,4 @@ double gammasamp(double a, double b);
 double gammaprob(double x, double a, double b);
 
 vector<string> split(const string& s, char delimiter);
+#endif


### PR DESCRIPTION
* Fix include guards, using new BEEPMBP package name as part of guard symbol
* simulate.hh did not have include guards at all, and wasn't included in file it provided the interface for, so fix this as well

SCRC-584